### PR TITLE
Addition of load_count to board_alight.txt

### DIFF
--- a/spec/en/reference.md
+++ b/spec/en/reference.md
@@ -1,6 +1,6 @@
 ## GTFS-ride
 
-**Current version published `September 6, 2017`. See [Revision History](../../CHANGES.md) for more details.**
+**Current version published `January 1, 2018`. See [Revision History](../../CHANGES.md) for more details.**
 
 This document explains the types of files that comprise a GTFS-ride dataset and defines the fields used in all of those files. The bolded files are those unique to GTFS-ride. They are not included in standard GTFS.
 

--- a/spec/en/reference.md
+++ b/spec/en/reference.md
@@ -96,8 +96,9 @@ File: **Optional**
 |   |  | * **8** - This **stop_time** was added to a scheduled trip, replacing something cancelled.    |
 | boardings | Optional | The **boardings** field contains the number of boardings at (or nearest to, in the case of boardings between stops ) the associated **stop_id** as collected by either automated or manual methods. Non-negative integer. |
 | alightings | Optional | The **alightings** field contains the number of alightings at (or nearest to, in the case of alightings between stops) the associated **stop_id** as collected by either automated or manual methods. Non-negative integer. |
-| current_load | Optional | The **current_load** field contains the calculated percentage current load of a vehicle at the identified stop. The state at which **current_load** is measured, is specified by **load_type**; if no value is given in **load_type**, **current_load** is arriving load.  Non-negative integer.|
-| load_type | Optional | The **load_type** field specifies the state (arriving or departing) at which **current_load** is measured. If no value is given, **current_load** indicates arriving load |
+| current_load | Optional | The **current_load** field contains the calculated percentage current load of a vehicle at the identified stop. **load_type** specifies the state at which **current_load** is measured; if no value is given in **load_type**, **current_load** is arriving load.  Non-negative integer.|
+| load_count | Optional | The **load_count** field contains the count of the number of riders onboard a vehicle at the identified stop. **load_type** specifies the state at which **load_count** is measured; if no value is given in **load_type**, **load_count** is arriving count.  Non-negative integer.
+| load_type | Optional | The **load_type** field specifies the state (arriving or departing) at which **current_load** and/or **load_count** is measured. |
 |   |  | * **0** - Arriving.  |
 |   |  | * **1** - Departing.  |
 | rack_down | Optional | The **rack_down** field indicates whether an external bike rack was deployed or remained down at the associated **stop_id**. This field should be used in conjunction with **bike_boardings** and **bike_alightings** if complete bike boarding and alighting counts are available. |


### PR DESCRIPTION
This change seeks to include a field called `load_count` in `board_alight.txt`. The purpose of this field would be to provide an absolute ridership count. Currently, without knowing a starting zero and/or vehicle capacity, there are no fields in GTFS-ride that could contain this data either directly or in a calculated manner. The change is sought to be included in the January 2018 quarterly review. 